### PR TITLE
set correct dnsfilter url

### DIFF
--- a/src/partials/adblock/faq.ejs
+++ b/src/partials/adblock/faq.ejs
@@ -152,7 +152,7 @@
 				<hr><br>
 				<h2>My ad-blocking solutions</h2>
 				<p>
-					I use <a id="dnsfilter-link" href="https://nextdns.io/">DNSFilter</a> as main DNS resolver<br>
+					I use <a id="dnsfilter-link" href="https://www.dnsfilter.com/">DNSFilter</a> as main DNS resolver<br>
 					Great alternative for home consumer users <a href="https://nextdns.io/">NextDNS</a>
 					Plus these combo on each platform : 
 				</p>


### PR DESCRIPTION
Both of the links under "my ad-blocking solutions" in the FAQ link to nextdns, since the issues are closed I assume this is the correct URL now.